### PR TITLE
`[feat]`: inject config and refactor network into network + clientenv `[DRIP-439]`

### DIFF
--- a/src/config/devnet/production/index.ts
+++ b/src/config/devnet/production/index.ts
@@ -4,4 +4,4 @@ export * from './vaults';
 export * from './tokens';
 export * from './vault-proto-configs';
 
-export const defaultProgramId = new PublicKey('F1NyoZsUhJzcpGyoEqpDNbUMKVvCnSXcCki1nN3ycAeo');
+export const programId = new PublicKey('dripTrkvSyQKvkyWg7oi4jmeEGMA5scSYowHArJ9Vwk');

--- a/src/config/devnet/production/tokens.ts
+++ b/src/config/devnet/production/tokens.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from '@solana/web3.js';
-import { Token } from '../types';
+import { Token } from '../../types';
 
 export const tokens: Record<string, Token> = {
   H9gBUJs5Kc5zyiKRTzZcYom4Hpj9VPHLy4VzExTVPgxa: {

--- a/src/config/devnet/production/vault-proto-configs.ts
+++ b/src/config/devnet/production/vault-proto-configs.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from '@solana/web3.js';
-import { VaultProtoConfig } from '../types';
+import { VaultProtoConfig } from '../../types';
 
 export const vaultProtoConfigs: Record<string, VaultProtoConfig> = {
   Gyp96fazJPVCHzWXXZGrTDeXKBUH9tfyyrVPhMZsRwUt: {

--- a/src/config/devnet/production/vaults.ts
+++ b/src/config/devnet/production/vaults.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from '@solana/web3.js';
-import { Vault } from '../types';
+import { Vault } from '../../types';
 
 export const vaults: Record<string, Vault> = {
   Bqkkq8AsaAyhgL53zEazJ1wYMqiHjEdF7osA8XAREE2q: {

--- a/src/config/devnet/staging/index.ts
+++ b/src/config/devnet/staging/index.ts
@@ -4,4 +4,4 @@ export * from './vaults';
 export * from './tokens';
 export * from './vault-proto-configs';
 
-export const defaultProgramId = new PublicKey('dripTrkvSyQKvkyWg7oi4jmeEGMA5scSYowHArJ9Vwk');
+export const programId = new PublicKey('F1NyoZsUhJzcpGyoEqpDNbUMKVvCnSXcCki1nN3ycAeo');

--- a/src/config/devnet/staging/tokens.ts
+++ b/src/config/devnet/staging/tokens.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from '@solana/web3.js';
-import { Token } from '../types';
+import { Token } from '../../types';
 
 export const tokens: Record<string, Token> = {
   H9gBUJs5Kc5zyiKRTzZcYom4Hpj9VPHLy4VzExTVPgxa: {

--- a/src/config/devnet/staging/vault-proto-configs.ts
+++ b/src/config/devnet/staging/vault-proto-configs.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from '@solana/web3.js';
-import { VaultProtoConfig } from '../types';
+import { VaultProtoConfig } from '../../types';
 
 export const vaultProtoConfigs: Record<string, VaultProtoConfig> = {
   Et3bqQq32LPkrndf8gU9gRqfL4S13ubdUuiqBE1jjrgr: {

--- a/src/config/devnet/staging/vaults.ts
+++ b/src/config/devnet/staging/vaults.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from '@solana/web3.js';
-import { Vault } from '../types';
+import { Vault } from '../../types';
 
 export const vaults: Record<string, Vault> = {
   BhRNxNFnPMxi4C8Y2trRY6hsGXa4iqJDjaJ5JPoCMQZB: {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -11,7 +11,12 @@ export interface Config {
   vaultProtoConfigs: Record<string, VaultProtoConfig>;
   vaults: Record<string, Vault>;
 }
-
+/*
+Valid Pairs: 
+- (Devnet, Staging)
+- (Devnet, Production)
+- (Mainnet, _), the same program on mainnet is used in all clientEnv's
+*/
 export function getConfig(network: Network, clientEnv: ClientEnv): Config {
   switch (network) {
     case Network.Mainnet:

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,21 +1,31 @@
 import { PublicKey } from '@solana/web3.js';
-import { Network } from '../models';
-import * as devnet from './devnet';
-import * as mainnet from './mainnet';
-import * as staging from './staging';
+import { ClientEnv, Network } from '../models';
+import * as devnetProd from './devnet/production';
+import * as mainnetProd from './mainnet/production';
+import * as devnetStaging from './devnet/staging';
 import { Vault, VaultProtoConfig, Token } from './types';
 
 export interface Config {
-  defaultProgramId: PublicKey;
+  programId: PublicKey;
   tokens: Record<string, Token>;
   vaultProtoConfigs: Record<string, VaultProtoConfig>;
   vaults: Record<string, Vault>;
 }
 
-export const Configs: Record<Network, Config> = {
-  [Network.MainnetProd]: mainnet,
-  [Network.DevnetProd]: devnet,
-  [Network.DevnetStaging]: staging,
-};
-
+export function getConfig(network: Network, clientEnv: ClientEnv): Config {
+  switch (network) {
+    case Network.Mainnet:
+      return mainnetProd;
+    case Network.Devnet:
+      switch (clientEnv) {
+        case ClientEnv.Production:
+          return devnetProd;
+        case ClientEnv.Staging:
+          return devnetStaging;
+      }
+    case Network.Localnet:
+    default:
+      throw new Error(`invalid (network, clientEnv): (${network}, ${clientEnv})`);
+  }
+}
 export * from './types';

--- a/src/config/mainnet/production/index.ts
+++ b/src/config/mainnet/production/index.ts
@@ -4,4 +4,4 @@ export * from './vaults';
 export * from './tokens';
 export * from './vault-proto-configs';
 
-export const defaultProgramId = new PublicKey('dripTrkvSyQKvkyWg7oi4jmeEGMA5scSYowHArJ9Vwk');
+export const programId = new PublicKey('dripTrkvSyQKvkyWg7oi4jmeEGMA5scSYowHArJ9Vwk');

--- a/src/config/mainnet/production/tokens.ts
+++ b/src/config/mainnet/production/tokens.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from '@solana/web3.js';
-import { Token } from '../types';
+import { Token } from '../../types';
 
 export const tokens: Record<string, Token> = {
   '7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs': {

--- a/src/config/mainnet/production/vault-proto-configs.ts
+++ b/src/config/mainnet/production/vault-proto-configs.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from '@solana/web3.js';
-import { VaultProtoConfig } from '../types';
+import { VaultProtoConfig } from '../../types';
 
 export const vaultProtoConfigs: Record<string, VaultProtoConfig> = {
   '6i3GfRb48FtUYB1e3UqfamT1D52UtGtTkF6tMF1F6YHv': {

--- a/src/config/mainnet/production/vaults.ts
+++ b/src/config/mainnet/production/vaults.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from '@solana/web3.js';
-import { Vault } from '../types';
+import { Vault } from '../../types';
 
 export const vaults: Record<string, Vault> = {
   '2dqTZ6Q3UDQTez6HviDjXFg9BNNvCpE9mEcV92peRacj': {

--- a/src/drip-client/index.ts
+++ b/src/drip-client/index.ts
@@ -1,6 +1,5 @@
 import { Address, AnchorProvider } from '@project-serum/anchor';
-import { PublicKey } from '@solana/web3.js';
-import { Configs } from '../config';
+import { Config } from '../config';
 import {
   DripAdminImpl,
   DripPositionImpl,
@@ -13,32 +12,40 @@ import { Network } from '../models';
 export class Drip {
   public readonly querier: DripQuerier;
   public readonly admin: DripAdmin;
-  public readonly programId: PublicKey;
 
   public constructor(
     public readonly network: Network,
     public readonly provider: AnchorProvider,
-    programId?: PublicKey
+    public readonly config: Config
   ) {
-    this.programId = programId ?? Configs[network].defaultProgramId;
-    this.querier = new DripQuerierImpl(provider, network, programId);
-    this.admin = new DripAdminImpl(provider, network, programId);
+    this.querier = new DripQuerierImpl(this.provider, config);
+    this.admin = new DripAdminImpl(provider, network, config.programId);
   }
 
   public async getPosition(pubkey: Address): Promise<DripPosition> {
-    return await DripPositionImpl.fromPosition(pubkey, this.provider, this.network, this.programId);
+    return await DripPositionImpl.fromPosition(
+      this.provider,
+      this.network,
+      this.config.programId,
+      pubkey
+    );
   }
 
   public async getPositionByMint(positionMint: Address): Promise<DripPosition> {
     return await DripPositionImpl.fromPositionNftMint(
-      positionMint,
       this.provider,
       this.network,
-      this.programId
+      this.config.programId,
+      positionMint
     );
   }
 
   public async getVault(pubkey: Address): Promise<DripVault> {
-    return await DripVaultImpl.fromVaultPubkey(pubkey, this.provider, this.network, this.programId);
+    return await DripVaultImpl.fromVaultPubkey(
+      this.provider,
+      this.network,
+      this.config.programId,
+      pubkey
+    );
   }
 }

--- a/src/implementations/drip-admin.ts
+++ b/src/implementations/drip-admin.ts
@@ -6,7 +6,6 @@ import {
   SYSVAR_RENT_PUBKEY,
   Transaction,
 } from '@solana/web3.js';
-import { Configs } from '../config';
 import { Drip } from '../idl/type';
 import DripIDL from '../idl/idl.json';
 import { DripAdmin } from '../interfaces';
@@ -28,10 +27,10 @@ import {
 } from '@solana/spl-token';
 import { findVaultPeriodPubkey, findVaultPubkey } from '../helpers';
 import { makeExplorerUrl } from '../utils/transaction';
+import { Config } from '../config';
 
 export class DripAdminImpl implements DripAdmin {
   private readonly vaultProgram: Program<Drip>;
-  private readonly programId: PublicKey;
 
   // For now we can do this, but we should transition to taking in a read-only connection here instead and
   // letting users only pass in signer at the end if they choose to else sign and broadcast the tx themselves
@@ -39,10 +38,8 @@ export class DripAdminImpl implements DripAdmin {
   constructor(
     private readonly provider: AnchorProvider,
     private readonly network: Network,
-    programId?: PublicKey
+    private readonly programId: PublicKey
   ) {
-    const config = Configs[network];
-    this.programId = programId ?? config.defaultProgramId;
     this.vaultProgram = new Program(DripIDL as unknown as Drip, this.programId, provider);
   }
 

--- a/src/implementations/drip-admin.ts
+++ b/src/implementations/drip-admin.ts
@@ -6,8 +6,7 @@ import {
   SYSVAR_RENT_PUBKEY,
   Transaction,
 } from '@solana/web3.js';
-import { Drip } from '../idl/type';
-import DripIDL from '../idl/idl.json';
+import { IDL, Drip } from '../idl/type';
 import { DripAdmin } from '../interfaces';
 import { InitVaultProtoConfigParams, InitVaultParams } from '../interfaces/drip-admin/params';
 import { Network } from '../models';
@@ -40,7 +39,7 @@ export class DripAdminImpl implements DripAdmin {
     private readonly network: Network,
     private readonly programId: PublicKey
   ) {
-    this.vaultProgram = new Program(DripIDL as unknown as Drip, this.programId, provider);
+    this.vaultProgram = new Program(IDL, this.programId, provider);
   }
 
   public getInitVaultProtoConfigPreview(

--- a/src/implementations/drip-position.ts
+++ b/src/implementations/drip-position.ts
@@ -7,10 +7,9 @@ import {
   TokenAccountNotFoundError,
   TokenInvalidAccountOwnerError,
 } from '@solana/spl-token';
-import { Drip } from '../idl/type';
+import { IDL, Drip } from '../idl/type';
 import { DripPosition } from '../interfaces';
 import { Network } from '../models';
-import DripIDL from '../idl/idl.json';
 import { getUnwrapSolInstructions, isSol, toPubkey } from '../utils';
 import {
   calculateWithdrawTokenAAmount,
@@ -38,7 +37,7 @@ export class DripPositionImpl implements DripPosition {
     private readonly programId: PublicKey,
     positionPubkey: Address
   ) {
-    this.vaultProgram = new Program(DripIDL as unknown as Drip, this.programId, provider);
+    this.vaultProgram = new Program(IDL, this.programId, provider);
     this.positionPubkey = toPubkey(positionPubkey);
   }
 
@@ -48,7 +47,7 @@ export class DripPositionImpl implements DripPosition {
     programId: Address,
     positionPubkey: Address
   ): Promise<DripPositionImpl> {
-    const vaultProgram = new Program(DripIDL as unknown as Drip, programId, provider);
+    const vaultProgram = new Program(IDL, programId, provider);
 
     const position = await vaultProgram.account.position.fetchNullable(positionPubkey);
     if (!position) {

--- a/src/implementations/drip-querier.ts
+++ b/src/implementations/drip-querier.ts
@@ -1,8 +1,7 @@
 import { Address, Program, AnchorProvider, BN } from '@project-serum/anchor';
 import { PublicKey } from '@solana/web3.js';
 import { Vault, Token, VaultProtoConfig } from '../config/types';
-import { Drip } from '../idl/type';
-import DripIDL from '../idl/idl.json';
+import { IDL, Drip } from '../idl/type';
 import { DripQuerier, QuoteToken } from '../interfaces';
 import {
   VaultAccount,
@@ -26,7 +25,7 @@ export class DripQuerierImpl implements DripQuerier {
   private readonly vaultProgram: Program<Drip>;
 
   constructor(provider: AnchorProvider, private readonly config: Config) {
-    this.vaultProgram = new Program(DripIDL as unknown as Drip, config.programId, provider);
+    this.vaultProgram = new Program(IDL, config.programId, provider);
   }
 
   async getAveragePrice(positionPubkey: Address, quoteToken: QuoteToken): Promise<Decimal> {

--- a/src/implementations/drip-querier.ts
+++ b/src/implementations/drip-querier.ts
@@ -1,6 +1,5 @@
 import { Address, Program, AnchorProvider, BN } from '@project-serum/anchor';
 import { PublicKey } from '@solana/web3.js';
-import { Configs } from '../config';
 import { Vault, Token, VaultProtoConfig } from '../config/types';
 import { Drip } from '../idl/type';
 import DripIDL from '../idl/idl.json';
@@ -11,7 +10,6 @@ import {
   VaultPositionAccount,
   VaultProtoConfigAccount,
 } from '../interfaces/drip-querier/results';
-import { Network } from '../models';
 import { toPubkey } from '../utils';
 import { getMint, TOKEN_PROGRAM_ID } from '@solana/spl-token';
 import { findVaultPeriodPubkey, findVaultPositionPubkey } from '../helpers';
@@ -22,15 +20,13 @@ import {
   VaultProtoConfigDoesNotExistError,
 } from '../errors';
 import Decimal from 'decimal.js';
+import { Config } from '../config';
 
 export class DripQuerierImpl implements DripQuerier {
   private readonly vaultProgram: Program<Drip>;
-  private readonly programId: PublicKey;
 
-  constructor(provider: AnchorProvider, private readonly network: Network, programId?: PublicKey) {
-    const config = Configs[network];
-    this.programId = programId ?? config.defaultProgramId;
-    this.vaultProgram = new Program(DripIDL as unknown as Drip, this.programId, provider);
+  constructor(provider: AnchorProvider, private readonly config: Config) {
+    this.vaultProgram = new Program(DripIDL as unknown as Drip, config.programId, provider);
   }
 
   async getAveragePrice(positionPubkey: Address, quoteToken: QuoteToken): Promise<Decimal> {
@@ -119,7 +115,7 @@ export class DripQuerierImpl implements DripQuerier {
 
   public async getAllVaults(): Promise<Record<string, Vault>> {
     // test
-    return Configs[this.network].vaults;
+    return this.config.vaults;
   }
 
   public async getAllPositions(user: Address): Promise<Record<string, VaultPositionAccount>> {
@@ -158,7 +154,7 @@ export class DripQuerierImpl implements DripQuerier {
   }
 
   public async getAllTokenAs(givenTokenB?: PublicKey): Promise<Record<string, Token>> {
-    const vaults = Configs[this.network].vaults;
+    const vaults = this.config.vaults;
     const tokenAPubkeys = (
       givenTokenB
         ? Object.values(vaults).filter((vault) => vault.tokenBMint.equals(givenTokenB))
@@ -168,14 +164,14 @@ export class DripQuerierImpl implements DripQuerier {
     return tokenAPubkeys.reduce(
       (map, tokenPubkey) => ({
         ...map,
-        [tokenPubkey.toBase58()]: Configs[this.network].tokens[tokenPubkey.toBase58()],
+        [tokenPubkey.toBase58()]: this.config.tokens[tokenPubkey.toBase58()],
       }),
       {} as Record<string, Token>
     );
   }
 
   public async getAllTokenBs(givenTokenA?: PublicKey): Promise<Record<string, Token>> {
-    const vaults = Configs[this.network].vaults;
+    const vaults = this.config.vaults;
     const tokenBPubkeys = (
       givenTokenA
         ? Object.values(vaults).filter((vault) => vault.tokenAMint.equals(givenTokenA))
@@ -185,7 +181,7 @@ export class DripQuerierImpl implements DripQuerier {
     return tokenBPubkeys.reduce(
       (map, tokenPubkey) => ({
         ...map,
-        [tokenPubkey.toBase58()]: Configs[this.network].tokens[tokenPubkey.toBase58()],
+        [tokenPubkey.toBase58()]: this.config.tokens[tokenPubkey.toBase58()],
       }),
       {} as Record<string, Token>
     );
@@ -195,7 +191,7 @@ export class DripQuerierImpl implements DripQuerier {
     tokenA: Address,
     tokenB: Address
   ): Promise<VaultProtoConfig[]> {
-    const vaults = Configs[this.network].vaults;
+    const vaults = this.config.vaults;
     const vaultsForPair = Object.values(vaults).filter(
       (vault) =>
         vault.tokenAMint.equals(toPubkey(tokenA)) && vault.tokenBMint.equals(toPubkey(tokenB))
@@ -209,7 +205,7 @@ export class DripQuerierImpl implements DripQuerier {
       {} as Partial<Record<string, boolean>>
     );
 
-    const vaultProtoConfigs = Configs[this.network].vaultProtoConfigs;
+    const vaultProtoConfigs = this.config.vaultProtoConfigs;
 
     return Object.values(vaultProtoConfigs).filter(
       (vaultProtoConfig) => !!vaultProtoConfigKeysForPairMap[vaultProtoConfig.pubkey.toBase58()]

--- a/src/implementations/drip-vault.ts
+++ b/src/implementations/drip-vault.ts
@@ -1,8 +1,7 @@
 import { Address, BN, Program, AnchorProvider } from '@project-serum/anchor';
-import { Drip } from '../idl/type';
+import { IDL, Drip } from '../idl/type';
 import { DripVault } from '../interfaces';
 import { Network } from '../models';
-import DripIDL from '../idl/idl.json';
 import {
   Keypair,
   PublicKey,
@@ -49,7 +48,7 @@ export class DripVaultImpl implements DripVault {
     private readonly programId: PublicKey,
     vaultPubkey: Address
   ) {
-    this.vaultProgram = new Program(DripIDL as unknown as Drip, this.programId, provider);
+    this.vaultProgram = new Program(IDL, this.programId, provider);
     this.vaultPubkey = toPubkey(vaultPubkey);
   }
 
@@ -60,7 +59,7 @@ export class DripVaultImpl implements DripVault {
     vaultSeeds: { protoConfig: Address; tokenAMint: Address; tokenBMint: Address }
   ): Promise<DripVaultImpl> {
     const vaultPubkey = findVaultPubkey(programId, vaultSeeds);
-    const vaultProgram = new Program(DripIDL as unknown as Drip, programId, provider);
+    const vaultProgram = new Program(IDL, programId, provider);
 
     const vault = await vaultProgram.account.vault.fetchNullable(vaultPubkey);
     if (!vault) {
@@ -76,7 +75,7 @@ export class DripVaultImpl implements DripVault {
     programId: Address,
     vaultPubkey: Address
   ): Promise<DripVaultImpl> {
-    const vaultProgram = new Program(DripIDL as unknown as Drip, programId, provider);
+    const vaultProgram = new Program(IDL, programId, provider);
 
     const vault = await vaultProgram.account.vault.fetchNullable(vaultPubkey);
     if (!vault) {

--- a/src/models/ClientEnv.ts
+++ b/src/models/ClientEnv.ts
@@ -1,0 +1,4 @@
+export enum ClientEnv {
+  Production,
+  Staging,
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,1 +1,2 @@
 export * from './network';
+export * from './ClientEnv';

--- a/src/models/network.ts
+++ b/src/models/network.ts
@@ -1,5 +1,5 @@
 export enum Network {
-  MainnetProd,
-  DevnetProd,
-  DevnetStaging,
+  Mainnet,
+  Devnet,
+  Localnet,
 }

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -2,10 +2,11 @@ import { Network } from '../models';
 
 export function makeExplorerUrl(txHash: string, network: Network): string {
   switch (network) {
-    case Network.MainnetProd:
+    case Network.Mainnet:
       return `https://explorer.solana.com/tx/${txHash}`;
-    case Network.DevnetProd:
-    case Network.DevnetStaging:
+    case Network.Devnet:
       return `https://explorer.solana.com/tx/${txHash}?cluster=devnet`;
+    case Network.Localnet:
+      return `https://explorer.solana.com/tx/${txHash}?cluster=custom&customUrl=http%3A%2F%2Flocalhost%3A8899`;
   }
 }


### PR DESCRIPTION
The PR:
- changes the entry points to accept a config 
  - This will allow clients to provide their own custom configs outside of our default hardcoded ones
-  Exposes a helper to fetch our hardcoded configs given a `Network` and `ClientEnv`
- Adds support for the local network for testing/debugging