### PR TITLE
`[fix]`: type of `dripTimestamp` in `VaultPeriod`

### DIFF
--- a/src/interfaces/drip-querier/results.ts
+++ b/src/interfaces/drip-querier/results.ts
@@ -31,7 +31,7 @@ export interface VaultPeriodAccount {
   periodId: BN;
   dar: BN;
   twap: BN;
-  dripTimestamp: number;
+  dripTimestamp: BN;
   bump: number;
 }
 


### PR DESCRIPTION
Anchor parses `dripTimestamp` (which is an `i64` in Rust) as a `BN`. We set the property in the type to `number`.